### PR TITLE
Remove YDStreamExtractor.disableDASHVideo call warning

### DIFF
--- a/lib/kodi65/utils.py
+++ b/lib/kodi65/utils.py
@@ -23,7 +23,6 @@ from kodi65 import addon
 
 
 def get_youtube_info(youtube_id):
-    YDStreamExtractor.disableDASHVideo(True)
     return YDStreamExtractor.getVideoInfo(youtube_id,
                                           quality=1)
 


### PR DESCRIPTION
Remove YDStreamExtractor.disableDASHVideo call warning as this is only available from addon settings, not callable anymore.