### PR TITLE
Fixed onup/down condition

### DIFF
--- a/resources/skins/Default/1080i/script-script.module.kodi65-t9search.xml
+++ b/resources/skins/Default/1080i/script-script.module.kodi65-t9search.xml
@@ -26,8 +26,8 @@
                 <height>708</height>
                 <onleft>9090</onleft>
                 <onright>Action(Close)</onright>
-                <onup condition="IntegerGreaterThan(Container(9091).NumItems,0)">Control.SetFocus(9091,999)</onup>
-                <ondown condition="IntegerGreaterThan(Container(9091).NumItems,0)">Control.SetFocus(9091,0)</ondown>
+                <onup condition="Integer.IsGreater(Container(9091).NumItems,0)">Control.SetFocus(9091,999)</onup>
+                <ondown condition="Integer.IsGreater(Container(9091).NumItems,0)">Control.SetFocus(9091,0)</ondown>
                 <onback>noop</onback>
                 <orientation>vertical</orientation>
                 <scrolltime tween="quadratic" easing="out">200</scrolltime>


### PR DESCRIPTION
Updated onup/down condition for control 9090 in accordance with latest available info on https://kodi.wiki/view/List_of_boolean_conditions#Integer.
This fixes inability to select any of the autocompletion entries in Extended Info Script's T9Search-dialog using remote or keyboard.